### PR TITLE
Don't require creating a coral_shards directory

### DIFF
--- a/demos/.gitignore
+++ b/demos/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 package-lock.json
 
-static/coral_shards/*.js
+static/coral.js

--- a/demos/compiler_settings.js
+++ b/demos/compiler_settings.js
@@ -7,7 +7,7 @@ var settings = {
     {
       path: './node_modules/@lockerdome/coral.js/plugins/compile_client_app',
       settings: {
-        shard_output_directory: 'static/coral_shards'
+        shard_output_directory: 'static'
       }
     }
   ]

--- a/demos/static/index.html
+++ b/demos/static/index.html
@@ -8,7 +8,7 @@
     <div id="app"></div>
     <script src="../../vendor/jquery-3.4.1.min.js"></script>
     <script src="../../vendor/bootstrap-4.3.1-dist/js/bootstrap.bundle.min.js"></script>
-    <script charset="utf-8" src="coral_shards/coral.js"></script>
+    <script charset="utf-8" src="coral.js"></script>
     <script>new Coral(document.getElementById('app'), {});</script>
   </body>
 </html>

--- a/hello_world/.gitignore
+++ b/hello_world/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 package-lock.json
 
-static/coral_shards/*.js
+static/coral.js

--- a/hello_world/compiler_settings.js
+++ b/hello_world/compiler_settings.js
@@ -7,7 +7,7 @@ var settings = {
     {
       path: './node_modules/@lockerdome/coral.js/plugins/compile_client_app',
       settings: {
-        shard_output_directory: 'static/coral_shards'
+        shard_output_directory: 'static'
       }
     }
   ]

--- a/hello_world/static/index.html
+++ b/hello_world/static/index.html
@@ -4,7 +4,7 @@
   </head>
   <body>
     <div id="app"></div>
-    <script charset="utf-8" src="coral_shards/coral.js"></script>
+    <script charset="utf-8" src="coral.js"></script>
     <script>new Coral(document.getElementById('app'), {});</script>
     <small>visit github: <a href="https://github.com/lockerdome/coral.js-tutorials" target="blank">coral.js-tutorials</a></small>
   </body>


### PR DESCRIPTION
Make the demos as easy as possible to get up and running.

Currently in order to build the hello world or demo app a `coral_shards` directory needs to be created. This shouldn't be necessary in order to build and run the demo apps.